### PR TITLE
RabbitMQ States

### DIFF
--- a/rabbitmq/init.sls
+++ b/rabbitmq/init.sls
@@ -1,6 +1,5 @@
-rabbitmq:
+rabbitmq-server:
   pkg:
-    - name: rabbitmq-server
     - installed
   service:
     - running

--- a/rabbitmq/project.sls
+++ b/rabbitmq/project.sls
@@ -7,7 +7,7 @@ broker-user-{{ pillar['project_name'] }}:
     - password: {{ pillar.get('secrets', {}).get('BROKER_PASSWORD') }}
     - force: True
     - require:
-      - service: rabbitmq
+      - service: rabbitmq-server
 
 broker-vhost-{{ pillar['project_name'] }}:
   rabbitmq_vhost.present:


### PR DESCRIPTION
Similar to the Nginx/Postgres states this does a few things:
- Installs rabbitmq
- Removes default user/vhost
- Adds a project state to create a project user/vhost from the expected pillar data
