### PR TITLE
Minor RabbitMQ Updates

### DIFF
--- a/rabbitmq/init.sls
+++ b/rabbitmq/init.sls
@@ -1,12 +1,32 @@
 rabbitmq-server:
+  pkgrepo.managed:
+    - name: deb http://www.rabbitmq.com/debian/ testing main
+    - key_url: http://www.rabbitmq.com/rabbitmq-signing-key-public.asc
   pkg:
     - installed
+    - require:
+      - pkgrepo: rabbitmq-server
   service:
     - running
     - enable: True
+    - require:
+      - pkg: rabbitmq-server
+    - watch:
+      - file: rabbitmq-config
 
 remove_defaults:
   rabbitmq_user.absent:
     - name: guest
   rabbitmq_vhost.absent:
     - name: /
+
+rabbitmq-config:
+  file.managed:
+    - name: /etc/rabbitmq/rabbitmq.config
+    - source: salt://rabbitmq/rabbitmq.config
+    - user: root
+    - group: root
+    - mode: 644
+    - template: jinja
+    - require:
+      - pkg: rabbitmq-server

--- a/rabbitmq/rabbitmq.config
+++ b/rabbitmq/rabbitmq.config
@@ -1,0 +1,6 @@
+[
+    {rabbit, [
+        {tcp_listeners, [5673]},
+        {vm_memory_high_watermark, 0.25}
+    ]}
+].


### PR DESCRIPTION
- Use latest RabbitMQ from repo 
- Lowers the highwatermark from 40% of the system memory to 25%
- Listens on all interfaces by default
