### PR TITLE
Upgrade setuptools

### DIFF
--- a/python/init.sls
+++ b/python/init.sls
@@ -24,11 +24,17 @@ python-headers:
       - libxml2-dev
       - libxslt1-dev
 
-pip:
+setuptools:
   pip.installed:
     - upgrade: True
     - require:
       - pkg: python-pkgs
+
+pip:
+  pip.installed:
+    - upgrade: True
+    - require:
+      - pip: setuptools
 
 virtualenv:
   pip.installed:


### PR DESCRIPTION
Fixes #14. This upgrades `setuptools` from the default version from apt before upgrading `pip` and `virtualenv`. For a new server this will install `setuptools` and `pip` from apt then upgrade `setuptools` using the current `pip` version. Then `pip` will upgrade itself. The one obvious place this will fail it the apt version of `pip` becomes so outdated that the most recent `setuptools` is no longer compatible.

**Note**: This does not fix servers which are already in a bad state with `setuptools < 0.8` and `pip >= 1.5`. Those servers need have `setuptools` upgraded manually.
