### PR TITLE
Set LANG and LC_ALL even if not present initially

### DIFF
--- a/locale/locale
+++ b/locale/locale
@@ -1,0 +1,2 @@
+LC_ALL=en_US.UTF-8
+LANG=en_US.UTF-8

--- a/locale/utf8.sls
+++ b/locale/utf8.sls
@@ -1,15 +1,7 @@
 # salt's locale.system only sets LANG but we want to set LC_ALL as well
-#es_ES.UTF-8:
-#  locale.system
 
-lang:
-  file.sed:
-    - name: /etc/default/locale
-    - before: ^LANG=.*
-    - after: LANG=en_US.UTF-8
-
-lc_all:
-  file.sed:
-    - name: /etc/default/locale
-    - before: ^LC_ALL=.*
-    - after: LC_ALL=en_US.UTF-8
+/etc/default/locale:
+  file.managed:
+    - source: salt://locale/locale
+    - user: root
+    - mode: 644


### PR DESCRIPTION
One of the AWS instances that we set up had `/etc/default/locale` present, but only LANG was set (LC_ALL was not in the file at all). Since LC_ALL wasn't set, Salt [defaults to setting it to C](https://github.com/saltstack/salt/blob/develop/salt/modules/cmdmod.py#L357). This PR just creates our `/etc/default/locale` to be what we want it to be. (Sorry for not pushing this earlier @calebsmith, if this, in fact, does solve the problem you were having yesterday)
