### PR TITLE
Make it easier to get the python you want in project-template

### DIFF
--- a/python/27.sls
+++ b/python/27.sls
@@ -1,7 +1,10 @@
 include:
   - python
 
-python-27-pkgs:
+exclude:
+  - python.33
+
+python-pkgs:
   pkg:
     - installed
     - names:

--- a/python/33.sls
+++ b/python/33.sls
@@ -1,7 +1,10 @@
 include:
   - python
 
-python-33-pkgs:
+exclude:
+  - python.27
+
+python-pkgs:
   pkg:
     - installed
     - names:


### PR DESCRIPTION
@mlavin what do you think about this? Then we could just include the correct python sls (python.33 or python.27) and have states depend on `python-pkgs`. (Rather than having to conditionally depend on `python-33-pkgs`, etc)
