### PR TITLE
Restore default RabbitMQ port number

### DIFF
--- a/rabbitmq/rabbitmq.config
+++ b/rabbitmq/rabbitmq.config
@@ -1,6 +1,6 @@
 [
     {rabbit, [
-        {tcp_listeners, [5673]},
+        {tcp_listeners, [5672]},
         {vm_memory_high_watermark, 0.25}
     ]}
 ].


### PR DESCRIPTION
@calebsmith noticed that RabbitMQ was not listening on the expected port 5672 https://www.rabbitmq.com/configure.html. This looks like a typo on my part when configuring this to listen on all interfaces.
