### PR TITLE
Reorder Postgres States

### DIFF
--- a/postgresql/init.sls
+++ b/postgresql/init.sls
@@ -21,7 +21,6 @@ postgresql:
     - cwd: /var/lib/postgresql
     - unless: psql -U postgres template1 -c 'SHOW SERVER_ENCODING' | grep "UTF8"
     - require:
-      - service: postgresql
       - file: /etc/default/locale
       - file: /var/lib/postgresql/configure_utf-8.sh
 


### PR DESCRIPTION
Fixes #19. Uploading the `configure_utf-8.sh` will fail if there is no postgres user. There is also no clear need to wait on the script before installing the postgres contrib packages.
