### PR TITLE
[fixes #23] '/' vhost is not removed any more.

### DIFF
--- a/rabbitmq/init.sls
+++ b/rabbitmq/init.sls
@@ -17,8 +17,6 @@ rabbitmq-server:
 remove_defaults:
   rabbitmq_user.absent:
     - name: guest
-  rabbitmq_vhost.absent:
-    - name: /
 
 rabbitmq-config:
   file.managed:


### PR DESCRIPTION
We still remove the guest user but the new version of rabbitmq requires the '/' vhost to exist to be able
to restart. There are no security implications with this change since there is no user to connect to
the default vhost.
