### PR TITLE
Supervisor service gets started too soon, so socket file doesn't get created

### DIFF
--- a/supervisor/pip.sls
+++ b/supervisor/pip.sls
@@ -5,12 +5,14 @@ supervisor:
       - pkg: python-pip
   pkg.removed:
     - name: supervisor
+
+supervisor_service:
   service:
+    - name: supervisor
     - running
     - enable: True
     - require:
-      - file: supervisor_conf
-      - file: supervisor_init
+      - pip: supervisor
     - watch:
       - file: supervisor_conf
       - file: supervisor_init


### PR DESCRIPTION
On a first highstate of the django-project-template, I get this error:

```
[33.33.33.10] out:   Name: /etc/supervisor/conf.d/testdpt-gunicorn.conf - Function: file.managed - Result: Changed
[33.33.33.10] out: ----------
[33.33.33.10] out:           ID: supervisor_update
[33.33.33.10] out:     Function: cmd.run
[33.33.33.10] out:         Name: supervisorctl update
[33.33.33.10] out:       Result: False
[33.33.33.10] out:      Comment: Command "supervisorctl update" run
[33.33.33.10] out:      Changes:   
[33.33.33.10] out:               ----------
[33.33.33.10] out:               pid:
[33.33.33.10] out:                   26319
[33.33.33.10] out:               retcode:
[33.33.33.10] out:                   2
[33.33.33.10] out:               stderr:
[33.33.33.10] out:                   
[33.33.33.10] out:               stdout:
[33.33.33.10] out:                   error: <class 'socket.error'>, [Errno 2] No such file or directory: file: /usr/lib/python2.7/socket.py line: 224
```

The error isn't the most straightforward, but it basically can't find the `/var/run/supervisor.sock` socket, and sure enough, right after the highstate, I get this:

```
vagrant@precise32:/var/run$ sudo supervisorctl status
unix:///var/run/supervisor.sock no such file
```

On the second highstate, the service gets started with no errors. 

I watched the salt-minion at debug level and for some reason, it tries to start the service **before** it pip installs supervisor. It's weird because the state file looks properly written to me. It's also weird that no errors get thrown when the service tries to start before the pip installs the actual binary.

I think @calebsmith ran into this, but I don't remember how/if you got around it.

Anyway, this PR works around the issue by forcing the service to require the pip installation.
