### PR TITLE
Fix dependencies so that pg_hba.conf is not overwritten

### DIFF
--- a/postgresql/init.sls
+++ b/postgresql/init.sls
@@ -24,7 +24,6 @@ postgresql:
     - cwd: /var/lib/postgresql
     - unless: psql -U postgres template1 -c 'SHOW SERVER_ENCODING' | grep "UTF8"
     - require:
-      - pkg: postgresql
       - file: /etc/default/locale
     - watch:
       - file: /var/lib/postgresql/configure_utf-8.sh
@@ -35,3 +34,5 @@ postgresql:
     - user: postgres
     - group: postgres
     - mode: 755
+    - require:
+      - pkg: postgresql


### PR DESCRIPTION
Make the command require the postgresql pkg to be present. I don't believe the service is required (and forcing it to depend on the service causes a circular requisite between the postgresql service and the pg_hba.conf `watch_in` requisite)

Also needs caktus/django-project-template#83 for a complete fix.
