### PR TITLE
update nginx state to increase server_names_hash_bucket_size

### DIFF
--- a/nginx/init.sls
+++ b/nginx/init.sls
@@ -5,6 +5,11 @@ nginx:
     - running
     - enable: True
 
+/etc/nginx/nginx.conf:
+  file.sed:
+    - before: "(# )?server_names_hash_bucket_size .+;"
+    - after: "server_names_hash_bucket_size 64;"
+
 remove_existing_conf:
   file.absent:
       - name: /etc/nginx/sites-enabled/default


### PR DESCRIPTION
For longer hostnames (especially, e.g., projectname-staging.caktusgroup.com) you can hit this error when deploying and nginx refuses to start:

http://charles.lescampeurs.org/2008/11/14/fix-nginx-increase-server_names_hash_bucket_size

This change updates just that line in the Ubuntu-provided nginx.conf. I opted not to pull the whole config into this repo, but that might be an option too, depending on whether we prefer to keep the distro config in case of Ubuntu updates or have more control by having the whole thing checked in to margarita.
