### PR TITLE
Add ghostscript as a required package.

### DIFF
--- a/python/init.sls
+++ b/python/init.sls
@@ -26,6 +26,7 @@ python-headers:
       - zlib1g-dev
       - libxml2-dev
       - libxslt1-dev
+      - ghostscript
 
 setuptools:
   pip.installed:


### PR DESCRIPTION
Pillow uses ghostscript to manipulate eps images. Without ghostscript
being installed an obscure "OSError: [Errno 2] No such file or directory"
is raised on attempts to manipulate eps images. Since Pillow is among our
default pip-installed packages we should ensure this utility is there
always as well.