### PR TITLE
Install latest Nginx from the stable PPA

### DIFF
--- a/nginx/init.sls
+++ b/nginx/init.sls
@@ -1,6 +1,14 @@
+nginx-ppa:
+  pkgrepo.managed:
+    - humanname: Nginx PPA
+    - ppa: nginx/stable
+    - require_in:
+      - pkg: nginx
+
 nginx:
-  pkg:
-    - installed
+  pkg.latest:
+    - name: nginx
+    - refresh: true
   service:
     - running
     - enable: True


### PR DESCRIPTION
Configures Nginx to be installed from the stable backport: https://launchpad.net/~nginx/+archive/ubuntu/stable This allows 14.04 to log Nginx logs to syslog which requires 1.7.1+ http://nginx.org/en/docs/syslog.html