### PR TITLE
Update RabbitMQ State

### DIFF
--- a/rabbitmq/init.sls
+++ b/rabbitmq/init.sls
@@ -2,10 +2,10 @@ rabbitmq-server:
   pkgrepo.managed:
     - name: deb http://www.rabbitmq.com/debian/ testing main
     - key_url: http://www.rabbitmq.com/rabbitmq-signing-key-public.asc
+    - require_in:
+      - pkg: rabbitmq-server
   pkg:
-    - installed
-    - require:
-      - pkgrepo: rabbitmq-server
+    - latest
   service:
     - running
     - enable: True

--- a/rabbitmq/init.sls
+++ b/rabbitmq/init.sls
@@ -6,6 +6,7 @@ rabbitmq-server:
       - pkg: rabbitmq-server
   pkg:
     - latest
+    - refresh: True
   service:
     - running
     - enable: True


### PR DESCRIPTION
Having a package require a pkgrepo doesn't work according to the docs. This updates the requirement declaration and ensures the latest rabbit is installed.