### PR TITLE
Fix file.sed

### DIFF
--- a/nginx/init.sls
+++ b/nginx/init.sls
@@ -6,9 +6,9 @@ nginx:
     - enable: True
 
 /etc/nginx/nginx.conf:
-  file.sed:
-    - before: "(# )?server_names_hash_bucket_size .+;"
-    - after: "server_names_hash_bucket_size 64;"
+  file.replace:
+    - pattern: "(# )?server_names_hash_bucket_size .+;"
+    - repl: " "
     - require_in:
       - service: nginx
 

--- a/nginx/init.sls
+++ b/nginx/init.sls
@@ -8,7 +8,7 @@ nginx:
 /etc/nginx/nginx.conf:
   file.replace:
     - pattern: "(# )?server_names_hash_bucket_size .+;"
-    - repl: " "
+    - repl: "server_names_hash_bucket_size 64;"
     - require_in:
       - service: nginx
 


### PR DESCRIPTION
File.sed is deprecated. I changed it to file.replace. I think that this is the only place in Margarita that file.sed is used. I tested this on the M3app staging server and it installed cleanly. 