### PR TITLE
Only install one postgres version; deprecate utf-8 cluster stuff

### DIFF
--- a/postgresql/init.sls
+++ b/postgresql/init.sls
@@ -12,6 +12,10 @@ db-packages:
       - postgresql-client-{{ pg_version }}
       - libpq-dev
 
+# The "postgresql" package is a meta package that depends
+# on whatever version of Postgres Ubuntu thinks is latest.
+# Make sure that's not installed because it can pull in the
+# wrong version for us.
 no_meta_postgresql:
   pkg:
     - removed
@@ -27,6 +31,9 @@ postgresql:
   require:
     - pkg: no_meta_postgresql
 
+{% if pg_version|float < 9.3 %}
+# With Postgres 9.3, the default DB cluster is UTF-8 so we don't need all this mess.
+# (Don't know if any older versions of PG are the same.)
 /var/lib/postgresql/configure_utf-8.sh:
   cmd.wait:
     - name: bash /var/lib/postgresql/configure_utf-8.sh
@@ -49,3 +56,4 @@ postgresql:
     - mode: 755
     - require:
       - pkg: postgresql
+{% endif %}

--- a/postgresql/init.sls
+++ b/postgresql/init.sls
@@ -12,12 +12,20 @@ db-packages:
       - postgresql-client-{{ pg_version }}
       - libpq-dev
 
+no_meta_postgresql:
+  pkg:
+    - removed
+    - name: postgresql
+
 postgresql:
   pkg:
     - installed
+    - name: postgresql-{{ pg_version }}
   service:
     - running
     - enable: True
+  require:
+    - pkg: no_meta_postgresql
 
 /var/lib/postgresql/configure_utf-8.sh:
   cmd.wait:

--- a/postgresql/project.sls
+++ b/postgresql/project.sls
@@ -19,4 +19,6 @@ database-{{ pillar['project_name'] }}:
     - lc_ctype: en_US.UTF-8
     - require:
       - postgres_user: user-{{ pillar['project_name'] }}
+{% if pg_version|float < 9.3 %}
       - file: /var/lib/postgresql/configure_utf-8.sh
+{% endif %}


### PR DESCRIPTION
Remove the "postgresql" meta-package and instead install the specific
    version of postgresql that we want.

    Don't need the hacks to make sure our PG cluster is UTF-8 once we get to
    postgres 9.3, because its clusters default to UTF-8.