### PR TITLE
Update proj template after release

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ To make a new release:
     git checkout develop
     git push origin develop --tags
 
-* If this release is ready to be used by new projects based on our [project
-  template](https://github.com/caktus/django-project-template), then be sure
+* If this release is ready to be used by new projects based on our `project
+  template <https://github.com/caktus/django-project-template>`_, then be sure
   to `update this tag
   <https://github.com/caktus/django-project-template/blob/master/conf/salt/margarita.sls#L8>`_

--- a/README.rst
+++ b/README.rst
@@ -57,3 +57,8 @@ To make a new release:
     git push origin master --tags
     git checkout develop
     git push origin develop --tags
+
+* If this release is ready to be used by new projects based on our [project
+  template](https://github.com/caktus/django-project-template), then be sure
+  to `update this tag
+  <https://github.com/caktus/django-project-template/blob/master/conf/salt/margarita.sls#L8>`_


### PR DESCRIPTION
If new projects are meant to use the new release, then it should be updated in django-project-template. 

Addresses caktus/django-project-template#192