### PR TITLE
Change ALLOWED_HOSTS to DOMAIN

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,7 +24,6 @@ v 1.0.8 on Sep 4, 2015
 * Add state to deploy elasticsearch (#72)
 * Note that New Relic high security shouldn't be enabled unless
   the account has it turned on. (#71)
->>>>>>> develop
 
 v 1.0.7 on Sep 3, 2015
 ----------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,23 @@ Margarita
 
 Changes - always add to the top.
 
+UNRELEASED
+----------
+
+* Set env var ``DOMAIN`` to contain the site's domain (from the Pillar). Remove
+  the env var ``ALLOWED_HOSTS`` which was previously holding that information.
+
+  Deprecation Note: Change any references to the ``ALLOWED_HOSTS`` env var to
+  instead be ``DOMAIN``. The most likely location where this is being used is
+  in the Django settings::
+
+    ALLOWED_HOSTS = os.environ['ALLOWED_HOSTS'].split(';')
+
+  should be changed to::
+
+    ALLOWED_HOSTS = [os.environ['DOMAIN']]
+
+
 v 1.0.4 on Aug 17, 2015
 -----------------------
 

--- a/project/django/manage.sh
+++ b/project/django/manage.sh
@@ -1,6 +1,6 @@
 # Shell script to setup necessary environment variables and run a management command
 export DJANGO_SETTINGS_MODULE='{{ settings }}'
-export ALLOWED_HOSTS='{{ pillar["domain"] }}'
+export DOMAIN='{{ pillar["domain"] }}'
 export ENVIRONMENT='{{ pillar["environment"] }}'
 {% for key, value in pillar.get('secrets', {}).items() + pillar.get('env', {}).items() %}
 export {{ key }}='{{ value }}'

--- a/project/web/gunicorn.conf
+++ b/project/web/gunicorn.conf
@@ -10,7 +10,7 @@ stopwaitsecs=60
 stdout_logfile={{ log_dir }}/gunicorn.log
 redirect_stderr=true
 stderr_logfile={{ log_dir }}/gunicorn.error.log
-environment=DJANGO_SETTINGS_MODULE="{{ settings }}",ENVIRONMENT="{{ pillar['environment'] }}",ALLOWED_HOSTS="{{ pillar['domain'] }}",
+environment=DJANGO_SETTINGS_MODULE="{{ settings }}",ENVIRONMENT="{{ pillar['environment'] }}",DOMAIN="{{ pillar['domain'] }}",
     {%- for key, value in pillar.get('secrets', {}).items() + pillar.get('env', {}).items() -%}
         {{ key }}="{{ value }}"{%- if not loop.last -%},{%- endif -%}
     {%- endfor -%}

--- a/project/worker/celery.conf
+++ b/project/worker/celery.conf
@@ -13,7 +13,7 @@ startsecs=1
 ; Need to wait for currently executing tasks to finish at shutdown.
 ; Increase this if you have very long running tasks.
 stopwaitsecs=60
-environment=DJANGO_SETTINGS_MODULE="{{ settings }}",ENVIRONMENT="{{ pillar['environment'] }}",ALLOWED_HOSTS="{{ pillar['domain'] }}",
+environment=DJANGO_SETTINGS_MODULE="{{ settings }}",ENVIRONMENT="{{ pillar['environment'] }}",DOMAIN="{{ pillar['domain'] }}",
     {%- for key, value in pillar.get('secrets', {}).items() + pillar.get('env', {}).items() -%}
         {{ key }}="{{ value }}"{%- if not loop.last -%},{%- endif -%}
     {%- endfor -%}


### PR DESCRIPTION
Closes #59

If accepted, the release notes will explain that users should grep for
instances of places that ALLOWED_HOSTS is set in their environment and change
it to DOMAIN instead.