### PR TITLE
Support dotenv in deploy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,9 +9,8 @@ UNRELEASED
 
   Upgrade Note: You must have installed and configured dotenv before upgrading
   your project repo to use this version of Margarita. See
-  https://github.com/caktus/django-project-template/pull/203 (wsgi) and
-  https://github.com/caktus/django-project-template/pull/208 (celery) for
-  examples.
+  https://github.com/caktus/django-project-template/pull/208 for examples on
+  code that you need to add for wsgi and celery processes.
 
 v 1.0.8 on Sep 4, 2015
 ----------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,17 @@ Margarita
 
 Changes - always add to the top.
 
+UNRELEASED
+----------
+
+* Remove duplicate specification of env vars (#65)
+
+  Upgrade Note: You must have installed and configured dotenv before upgrading
+  your project repo to use this version of Margarita. See
+  https://github.com/caktus/django-project-template/pull/203 (wsgi) and
+  https://github.com/caktus/django-project-template/pull/208 (celery) for
+  examples.
+
 v 1.0.8 on Sep 4, 2015
 ----------------------
 

--- a/project/django/init.sls
+++ b/project/django/init.sls
@@ -14,7 +14,6 @@ manage:
     - mode: 700
     - template: jinja
     - context:
-        settings: "{{ pillar['project_name']}}.settings.deploy"
         virtualenv_root: "{{ vars.venv_dir }}"
         directory: "{{ vars.source_dir }}"
     - require:

--- a/project/django/manage.sh
+++ b/project/django/manage.sh
@@ -1,9 +1,3 @@
-# Shell script to setup necessary environment variables and run a management command
-export DJANGO_SETTINGS_MODULE='{{ settings }}'
-export ALLOWED_HOSTS='{{ pillar["domain"] }}'
-export ENVIRONMENT='{{ pillar["environment"] }}'
-{% for key, value in pillar.get('secrets', {}).items() + pillar.get('env', {}).items() %}
-export {{ key }}='{{ value }}'
-{% endfor %}
+# Shell script to run a management command
 cd {{ directory }}
 {{ virtualenv_root }}/bin/python {{ directory }}/manage.py $@

--- a/project/dotenv
+++ b/project/dotenv
@@ -1,0 +1,6 @@
+DJANGO_SETTINGS_MODULE='{{ pillar["project_name"]}}.settings.deploy'
+ALLOWED_HOSTS='{{ pillar["domain"] }}'
+ENVIRONMENT='{{ pillar["environment"] }}'
+{% for key, value in pillar.get('secrets', {}).items() + pillar.get('env', {}).items() %}
+{{ key }}='{{ value }}'
+{% endfor %}

--- a/project/repo.sls
+++ b/project/repo.sls
@@ -63,3 +63,15 @@ delete_pyc:
     - user: {{ pillar['project_name'] }}
     - require:
         - file: project_repo
+
+# Now that we have a repo, we can set up our .env inside it
+dotenv:
+  file.managed:
+    - name: {{ vars.build_path(vars.source_dir, ".env") }}
+    - source: salt://project/dotenv
+    - user: {{ pillar['project_name'] }}
+    - group: {{ pillar['project_name'] }}
+    - mode: 700
+    - template: jinja
+    - require:
+      - file: project_repo

--- a/project/web/gunicorn.conf
+++ b/project/web/gunicorn.conf
@@ -10,7 +10,3 @@ stopwaitsecs=60
 stdout_logfile={{ log_dir }}/gunicorn.log
 redirect_stderr=true
 stderr_logfile={{ log_dir }}/gunicorn.error.log
-environment=DJANGO_SETTINGS_MODULE="{{ settings }}",ENVIRONMENT="{{ pillar['environment'] }}",ALLOWED_HOSTS="{{ pillar['domain'] }}",
-    {%- for key, value in pillar.get('secrets', {}).items() + pillar.get('env', {}).items() -%}
-        {{ key }}="{{ value }}"{%- if not loop.last -%},{%- endif -%}
-    {%- endfor -%}

--- a/project/worker/celery.conf
+++ b/project/worker/celery.conf
@@ -13,7 +13,3 @@ startsecs=1
 ; Need to wait for currently executing tasks to finish at shutdown.
 ; Increase this if you have very long running tasks.
 stopwaitsecs=60
-environment=DJANGO_SETTINGS_MODULE="{{ settings }}",ENVIRONMENT="{{ pillar['environment'] }}",ALLOWED_HOSTS="{{ pillar['domain'] }}",
-    {%- for key, value in pillar.get('secrets', {}).items() + pillar.get('env', {}).items() -%}
-        {{ key }}="{{ value }}"{%- if not loop.last -%},{%- endif -%}
-    {%- endfor -%}


### PR DESCRIPTION
Closes #65 

A couple issues that I still need to address:
- [x] Docs for adding `dotenv` command to `celery.py` so that celery workers can access the environment
- [x] Figure out how to coordinate this with the corresponding project-template PR
