### PR TITLE
New Relic high security has to be enabled in the account

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -163,8 +163,9 @@ To enable New Relic monitoring for an environment:
 
     # project.sls
     env:
-        NEW_RELIC_HIGH_SECURITY: "true"
         NEW_RELIC_LOG: "/var/log/newrelic/agent.log"
+        # Only if your account has high security enabled:
+        NEW_RELIC_HIGH_SECURITY: "true"
 
     # <environment>.sls
     env:


### PR DESCRIPTION
Otherwise, if you enable it in your own settings,
the NR server won't talk to you.