### PR TITLE
Elasticsearch

### DIFF
--- a/elasticsearch/default
+++ b/elasticsearch/default
@@ -1,0 +1,1 @@
+ES_HEAP_SIZE=256m

--- a/elasticsearch/elasticsearch.yml
+++ b/elasticsearch/elasticsearch.yml
@@ -1,1 +1,5 @@
 network.bind_host: 127.0.0.1
+cluster:
+  name: {{ pillar['project_name'] }}_{{ pillar['environment'] }}
+node:
+  name: {{ grains['id'] }}

--- a/elasticsearch/elasticsearch.yml
+++ b/elasticsearch/elasticsearch.yml
@@ -1,0 +1,1 @@
+network.bind_host: 127.0.0.1

--- a/elasticsearch/init.sls
+++ b/elasticsearch/init.sls
@@ -1,0 +1,61 @@
+# This is the family of versions, not the exact version.
+# E.g. 1.7 will get the latest 1.7.* release
+{% set elasticsearch_version = salt['pillar.get']('elasticsearch_version', '1.7') %}
+
+elasticsearch-apt-repo:
+  pkgrepo.managed:
+    - name: 'deb http://packages.elastic.co/elasticsearch/{{ elasticsearch_version }}/debian stable main'
+    - file: /etc/apt/sources.list.d/elasticsearch-{{ elasticsearch_version }}.list
+    - key_url: https://packages.elastic.co/GPG-KEY-elasticsearch
+    - refresh_db: true
+    - require_in:
+        pkg: elasticsearch
+
+java:
+  pkg.installed:
+    - name: default-jre
+
+elasticsearch:
+  pkg.installed:
+    - name: elasticsearch
+    - require:
+      - pkg: java
+  service.running:
+    - enable: True
+    - watch:
+      - file: elasticsearch_conf
+      - file: elasticsearch_default
+    - require:
+      - pkg: elasticsearch
+
+elasticsearch_conf:
+  file.managed:
+    - name: /etc/elasticsearch/elasticsearch.yml
+    - source: salt://project/search/elasticsearch.yml
+    - mode: 644
+    - user: root
+    - group: root
+    - require:
+      - pkg: elasticsearch
+
+elasticsearch_default:
+  file.managed:
+    - name: /etc/default/elasticsearch
+    - source: salt://project/search/default
+    - mode: 644
+    - user: root
+    - group: root
+    - require:
+      - pkg: elasticsearch
+
+security_limits:
+  file.managed:
+    - name: /etc/security/limits.d/99-elasticsearch.conf
+    - contents: |
+        # increase the number of open files for elasticsearch
+        root    soft    nofile  65536
+        root    hard    nofile  65536
+        root    -       memlock unlimited
+    - mode: 644
+    - user: root
+    - group: root

--- a/elasticsearch/init.sls
+++ b/elasticsearch/init.sls
@@ -31,7 +31,7 @@ elasticsearch:
 elasticsearch_conf:
   file.managed:
     - name: /etc/elasticsearch/elasticsearch.yml
-    - source: salt://project/search/elasticsearch.yml
+    - source: salt://elasticsearch/elasticsearch.yml
     - mode: 644
     - user: root
     - group: root
@@ -41,7 +41,7 @@ elasticsearch_conf:
 elasticsearch_default:
   file.managed:
     - name: /etc/default/elasticsearch
-    - source: salt://project/search/default
+    - source: salt://elasticsearch/default
     - mode: 644
     - user: root
     - group: root

--- a/elasticsearch/init.sls
+++ b/elasticsearch/init.sls
@@ -32,6 +32,7 @@ elasticsearch_conf:
   file.managed:
     - name: /etc/elasticsearch/elasticsearch.yml
     - source: salt://elasticsearch/elasticsearch.yml
+    - template: jinja
     - mode: 644
     - user: root
     - group: root


### PR DESCRIPTION
Add state for deploying elasticsearch on our servers.

This sets them up to listen only on localhost. It sets the cluster name to the "project_env" and the node name to the Salt minion ID.

Thanks to Mark for most of the code here.