### PR TITLE
Symlink lessc to /usr/bin

### DIFF
--- a/project/web/app.sls
+++ b/project/web/app.sls
@@ -70,6 +70,12 @@ less:
     - unless: "which lessc && lessc --version | grep {{ pillar['less_version'] }}"
     - require:
       - pkg: node-pkgs
+  file.symlink:
+    - name: /usr/bin/lessc
+    - target: /usr/local/bin/lessc
+    - user: root
+    - require:
+      - cmd: less
 
 collectstatic:
   cmd.run:


### PR DESCRIPTION
... so that gunicorn can find it.

Closes #75