### PR TITLE
Turn off elasticsearch multicast

### DIFF
--- a/elasticsearch/elasticsearch.yml
+++ b/elasticsearch/elasticsearch.yml
@@ -3,3 +3,7 @@ cluster:
   name: {{ pillar['project_name'] }}_{{ pillar['environment'] }}
 node:
   name: {{ grains['id'] }}
+
+# Don't form ad-hoc clusters
+# See https://www.elastic.co/guide/en/elasticsearch/guide/current/_important_configuration_changes.html#_prefer_unicast_over_multicast
+discovery.zen.ping.multicast.enabled: false


### PR DESCRIPTION
So elasticsearch doesn't take it upon itself to
form ad-hoc clusters.