### PR TITLE
Get required Erlang version for Ubuntu 12.04

### DIFF
--- a/rabbitmq/init.sls
+++ b/rabbitmq/init.sls
@@ -1,3 +1,20 @@
+{% if grains['lsb_distrib_codename'] == 'precise' %}
+# Rabbitmq-server now needs a newer Erlang than the repos provide in 12.04.
+# We can get that from erlang-solutions.com for 12.04, but not anything
+# older than that, so we only address 12.04 here.
+erlang:
+  pkgrepo.managed:
+    - name: deb http://packages.erlang-solutions.com/ubuntu {{ grains['lsb_distrib_codename'] }} contrib
+    - key_url: http://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc
+    - require_in:
+      - pkg: erlang-nox
+  pkg.latest:
+    - name: erlang-nox
+    - refresh: true
+    - require_in:
+      - pkg: rabbitmq-server
+{% endif %}
+
 rabbitmq-server:
   pkgrepo.managed:
     - name: deb http://www.rabbitmq.com/debian/ testing main


### PR DESCRIPTION
The latest RabbitMQ requires a newer version of Erlang than
it used to, and Ubuntu 12.04 doesn't have it.  If we're on
12.04, get Erlang from erlang-solutions.com's repo.