### PR TITLE
Send unattended upgrade results to syslog

### DIFF
--- a/forward_logs/init.sls
+++ b/forward_logs/init.sls
@@ -1,3 +1,6 @@
+include:
+  - syslog
+
 send_logs_to_remote_log_server:
   file.managed:
     - name: /etc/rsyslog.d/remote_log_server.conf

--- a/syslog/init.sls
+++ b/syslog/init.sls
@@ -1,0 +1,20 @@
+# We need rsyslog 8.5+ to monitor plaintext log files using wildcards
+rsyslog:
+  pkgrepo.managed:
+    - ppa: adiscon/v8-stable
+  pkg.latest:
+    - name: rsyslog
+    - refresh: True
+
+# Load the imfile module so we can monitor plaintext log files
+load_imfile:
+  file.prepend:
+    - name: /etc/rsyslog.conf
+    - text: |
+        module(load="imfile" PollingInterval="10")
+
+restart_rsyslog_if_imfile_added:
+  cmd.run:
+    - name: service rsyslog restart
+    - onchanges:
+       - file: load_imfile

--- a/syslog/init.sls
+++ b/syslog/init.sls
@@ -15,6 +15,6 @@ load_imfile:
 
 restart_rsyslog_if_imfile_added:
   cmd.run:
-    - name: service rsyslog restart
+    - name: restart rsyslog
     - onchanges:
        - file: load_imfile

--- a/unattended_upgrades/rsyslog_unattended.conf
+++ b/unattended_upgrades/rsyslog_unattended.conf
@@ -1,0 +1,5 @@
+input(type="imfile"
+      File="/var/log/unattended-upgrades/*.log"
+      Tag="unattended"
+      Severity="info"
+      Facility="local7")


### PR DESCRIPTION
Use rsyslog feature to monitor the plain text log files from
unattended upgrades and add them as syslog messages.