### PR TITLE
Stop force-refreshing the package database to speed things up

### DIFF
--- a/newrelic_sysmon/init.sls
+++ b/newrelic_sysmon/init.sls
@@ -14,7 +14,6 @@ newrelic_repo:
 newrelic_sysmon_pkg:
   pkg.latest:
     - name: newrelic-sysmond
-    - refresh: true
 # Note: according to the docs, `require`ing a pkgrepo from a pkg does
 # not work, you have to `require_in` the pkg from the pkgrepo.
 

--- a/nginx/init.sls
+++ b/nginx/init.sls
@@ -8,7 +8,6 @@ nginx-ppa:
 nginx:
   pkg.latest:
     - name: nginx
-    - refresh: true
   service:
     - running
     - enable: True

--- a/rabbitmq/init.sls
+++ b/rabbitmq/init.sls
@@ -10,7 +10,6 @@ erlang:
       - pkg: erlang-nox
   pkg.latest:
     - name: erlang-nox
-    - refresh: true
     - require_in:
       - pkg: rabbitmq-server
 {% endif %}
@@ -23,7 +22,6 @@ rabbitmq-server:
       - pkg: rabbitmq-server
   pkg:
     - latest
-    - refresh: True
   service:
     - running
     - enable: True

--- a/syslog/init.sls
+++ b/syslog/init.sls
@@ -4,7 +4,6 @@ rsyslog:
     - ppa: adiscon/v8-stable
   pkg.latest:
     - name: rsyslog
-    - refresh: True
 
 # Load the imfile module so we can monitor plaintext log files
 load_imfile:


### PR DESCRIPTION
This appears to not break initial deploys, while significantly
speeding up subsequent deploys.