### PR TITLE
Python 2.7 Backport

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,6 +101,17 @@ project_name
     and no spaces or punctuation other than underscore.
 python_version
     What version of Python the project uses, e.g. "2.7" or "3.4".
+python_backport
+    If using Python 2.7 then setting this to ``True`` will enable the Python 2.7.9+ backport
+    for network security enhancements. See https://www.python.org/dev/peps/pep-0466/
+python_headers
+    This is a list of additional header files which are required to install the virtualenv
+    dependencies. For example::
+
+    python_headers:
+      - libldap2-dev
+      - libsasl2-dev
+
 repo
     Where to get the project code.  ``url`` should be a URL in the format you'd use
     with ``git clone``, like ``git@github.com:CHANGEME/CHANGEME.git``

--- a/project/venv.sls
+++ b/project/venv.sls
@@ -6,6 +6,10 @@ include:
   - python
 
 venv:
+  file.absent:
+    - name: {{ vars.venv_dir }}
+    - onchanges:
+      - pkg: python-pkgs
   virtualenv.managed:
     - name: {{ vars.venv_dir }}
     - python: {{ '/usr/bin/python' ~ pillar['python_version'] }}
@@ -14,6 +18,7 @@ venv:
       - pip: virtualenv
       - file: root_dir
       - file: project_repo
+      - file: venv
       - pkg: python-pkgs
 
 pip_requirements:

--- a/python/init.sls
+++ b/python/init.sls
@@ -1,7 +1,20 @@
+{% set python_version = pillar.get('python_version', '2.7') ~ '' %}
+
 deadsnakes:
   pkgrepo.managed:
     - humanname: Deadsnakes PPA
     - ppa: fkrull/deadsnakes
+    - require_in:
+      - pkg: python-pkgs
+
+{% if python_version == '2.7' and pillar.get('python_backport') %}
+deadsnakes-python2.7:
+  pkgrepo.managed:
+    - humanname: Deadsnakes PPA for 2.7
+    - ppa: fkrull/deadsnakes-python2.7
+    - require_in:
+      - pkg: python-pkgs
+{% endif %}
 
 python-pkgs:
   pkg:
@@ -22,10 +35,11 @@ python-pkgs:
       - libxml2-dev
       - libxslt1-dev
       - ghostscript
-      - python{{ pillar['python_version'] }}
-      - python{{ pillar['python_version'] }}-dev
-    - require:
-      - pkgrepo: deadsnakes
+      - python{{ python_version }}
+      - python{{ python_version }}-dev
+{% for name in pillar.get('python_headers', []) %}
+      - {{ name }}
+{% endfor %}
 
 setuptools:
   pip.installed:

--- a/python/init.sls
+++ b/python/init.sls
@@ -17,9 +17,8 @@ deadsnakes-python2.7:
 {% endif %}
 
 python-pkgs:
-  pkg:
-    - installed
-    - names:
+  pkg.installed:
+    - pkgs:
       - python-pip
       - build-essential
       - libpq-dev


### PR DESCRIPTION
Fixes #64. There is a separate PPA for the Python 2.7.9+ backport. This adds a new pillar option to enable it when using Python 2.7. Somewhat related, it adds another option to include additional header files required for the Python dependencies. If the Python version or any of those headers change then the virtualenv is rebuilt. They are now installed with single command so we can track their changes.

Tested locally with the Tracpro deployment which needs this SSL backport.