### PR TITLE
Install Base Packages in a Single Command

### DIFF
--- a/base/init.sls
+++ b/base/init.sls
@@ -1,7 +1,6 @@
 base-packages:
-  pkg:
-    - installed
-    - names:
+  pkg.installed:
+    - pkgs:
       - python-software-properties
       - dpkg-dev
       - wget


### PR DESCRIPTION
`pkgs` is preferred in the documentation as noted here: https://docs.saltstack.com/en/latest/ref/states/all/salt.states.pkg.html

> Unlike pkgs, the names parameter cannot specify a version. In addition, it makes a separate call to the package management frontend to install each package, whereas pkgs makes just a single call. It is therefore recommended to use pkgs instead of names to install multiple packages, both for the additional features and the performance improvement that it brings.