### PR TITLE
Fix Supervisor State Dependency

### DIFF
--- a/supervisor/pip.sls
+++ b/supervisor/pip.sls
@@ -2,7 +2,7 @@ supervisor:
   pip.installed:
     - name: supervisor==3.0
     - require:
-      - pkg: python-pip
+      - pip: pip
   pkg.removed:
     - name: supervisor
 


### PR DESCRIPTION
One consequence of combining the package states in #106 is that you can't depend on them individually. It turns out that there was a place depending on `pkg: python-pip` which is no longer a valid state. Updated to depend on pip installing pip. This could also be updated to `pkg: python-pkgs`.