### PR TITLE
Fix sudo state dependencies and minor clean up

### DIFF
--- a/sudo/init.sls
+++ b/sudo/init.sls
@@ -1,15 +1,15 @@
-sudo:
-  service:
-    - running
-    - enable: True
-    - reload: True
-    - watch:
-      - pkg: sudo
-
-
 /etc/sudoers.d/admin:
   file.managed:
     - source: salt://sudo/sudoers.d/admin
     - user: root
     - mode: 440
 
+sudo:
+  service:
+    - running
+    - enable: True
+    - reload: True
+    - require:
+      - pkg: base-packages
+    - watch:
+      - file: /etc/sudoers.d/admin


### PR DESCRIPTION
Similar to #111. This dependency was broken when the `base-packages` was changed to use `pkgs` instead of `names`.