### PR TITLE
No stopasgroup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,11 @@ Margarita
 
 Changes - always add to the top.
 
+v 1.6.5 (unreleased)
+--------------------
+
+* Change default value for `stopasgroup` to `false` for gunicorn and celery
+
 v 1.6.4 on Mar 3, 2016
 ----------------------
 

--- a/project/web/gunicorn.conf
+++ b/project/web/gunicorn.conf
@@ -4,7 +4,7 @@ user={{ pillar['project_name'] }}
 directory={{ directory }}
 autostart=true
 autorestart=true
-stopasgroup=true
+stopasgroup=false
 killasgroup=true
 stopwaitsecs=60
 # Supervisor 3.x:

--- a/project/worker/celery.conf
+++ b/project/worker/celery.conf
@@ -4,7 +4,7 @@ user={{ pillar['project_name'] }}
 directory={{ directory }}
 autostart=true
 autorestart=true
-stopasgroup=true
+stopasgroup=false
 killasgroup=true
 startsecs=1
 ; Need to wait for currently executing tasks to finish at shutdown.


### PR DESCRIPTION
`stopasgroup` sends the original term signal to the child processes. In the case of Celery, that propagates as an immediate error (`WorkerLostError: Worker exited prematurely: signal 15 (SIGTERM)` email). By turning this off, child processes will have `killwaitseconds` to actually complete their task.