### PR TITLE
Break apart "repo" pillar into "branch" and "repo"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@ Margarita
 
 Changes - always add to the top.
 
-v 1.7.0 (unreleased)
+v 1.6.7 (unreleased)
 --------------------
 
 * Allow specifying the branch to deploy in the 'branch' pillar variable.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,10 +6,29 @@ v 1.6.7 (unreleased)
 --------------------
 
 * Allow specifying the branch to deploy in the 'branch' pillar variable.
-    - Most projects should now be able to specify repo + url just once,
-      in `project.sls`.
-    - With this structure, the branch to deploy can now easily be overridden
-      from the command line. See Salt docs:
+    - NOTE: These changes are fully backwards compatible; no pillar changes
+      are required to update but structure simplifications are now possible.
+    - Most projects will be able to specify the repo just once, in `project.sls`::
+
+        repo:
+            url: git@github.com/user/project.git
+
+    - Projects which deploy the `master` branch to their production
+      environments may only need to change the `branch` pillar in their
+      staging environments::
+
+        branch: develop
+
+    - With this structure, the deploy branch can be easily overridden from
+      the command line::
+
+        salt '*' -l info highstate pillar='{"branch": "hotfix"}'
+
+      Corresponding changes in caktus/django-project-template show how
+      this can be used to deploy a non-default branch using Fabric with no
+      need to edit the pillar file.
+
+      For more info, see the Salt documentation:
       https://docs.saltstack.com/en/latest/topics/pillar/#set-pillar-data-at-the-command-line
 
 v 1.6.6 on Mar 21, 2016

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,12 @@ Changes - always add to the top.
 v 1.7.0 (unreleased)
 --------------------
 
-* Break apart 'repo' pillar into 'branch' and 'repo'. You will need to update
-  your pillars.
+* Allow specifying the branch to deploy in the 'branch' pillar variable.
+    - Most projects should now be able to specify repo + url just once,
+      in `project.sls`.
+    - With this structure, the branch to deploy can now easily be overridden
+      from the command line. See Salt docs:
+      https://docs.saltstack.com/en/latest/topics/pillar/#set-pillar-data-at-the-command-line
 
 v 1.6.5 on Mar 15, 2016
 -----------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,12 @@ Margarita
 
 Changes - always add to the top.
 
+v 1.7.0 (unreleased)
+--------------------
+
+* Break apart 'repo' pillar into 'branch' and 'repo'. You will need to update
+  your pillars.
+
 v 1.6.4 on Mar 3, 2016
 ----------------------
 

--- a/project/repo.sls
+++ b/project/repo.sls
@@ -34,8 +34,8 @@ project_repo:
        - cmd: project_repo
   {% else %}
   git.latest:
-    - name: "{{ pillar['repo'] }}"
-    - rev: "{{ pillar.get('branch', 'master') }}"
+    - name: "{{ pillar['repo']['url'] }}"
+    - rev: "{{ pillar.get('branch', pillar['repo'].get('branch', 'master')) }}"
     - target: {{ vars.source_dir }}
     - force_checkout: True
     - user: {{ pillar['project_name'] }}

--- a/project/repo.sls
+++ b/project/repo.sls
@@ -34,8 +34,8 @@ project_repo:
        - cmd: project_repo
   {% else %}
   git.latest:
-    - name: "{{ pillar['repo']['url'] }}"
-    - rev: "{{ pillar['repo'].get('branch', 'master') }}"
+    - name: "{{ pillar['repo'] }}"
+    - rev: "{{ pillar.get('branch', 'master') }}"
     - target: {{ vars.source_dir }}
     - force_checkout: True
     - user: {{ pillar['project_name'] }}


### PR DESCRIPTION
There's a nifty command line trick for salt to pass in pillar data. If we break apart this pillar then we can easily override the branch in the `deploy` Fabric command.

See also:
https://github.com/caktus/django-project-template/pull/251
https://github.com/caktus/developer-documentation/pull/44