### PR TITLE
Fix updates to the letsencrypt installation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,13 @@ Margarita
 
 Changes - always add to the top.
 
+v 1.7.1 on May 24, 2016
+-----------------------
+
+* Reset the letsencrypt git repo each time before pulling, to avoid an
+  error due to a dirty working tree caused by letsencrypt's built-in updater.
+
+
 v 1.7.0 on May 16, 2016
 -----------------------
 

--- a/project/web/balancer.sls
+++ b/project/web/balancer.sls
@@ -171,6 +171,7 @@ install_letsencrypt:
     - name: https://github.com/letsencrypt/letsencrypt/
     - target: {{ letsencrypt_dir }}
     - force_checkout: True
+    - force_reset: True
 
 # Run letsencrypt to get a key and certificate
 run_letsencrypt:

--- a/project/web/balancer.sls
+++ b/project/web/balancer.sls
@@ -170,6 +170,7 @@ install_letsencrypt:
   git.latest:
     - name: https://github.com/letsencrypt/letsencrypt/
     - target: {{ letsencrypt_dir }}
+    - force_checkout: True
 
 # Run letsencrypt to get a key and certificate
 run_letsencrypt:


### PR DESCRIPTION
letsencrypt-auto has its own updater that runs every time you execute,
so the git checkout winds up being dirty, and fails to update.  So,
pass `force_checkout: True` to the `git.latest` state to throw away
the changes to the working tree.
