### PR TITLE
Manually reset letsencrypt git checkout

### DIFF
--- a/project/web/balancer.sls
+++ b/project/web/balancer.sls
@@ -168,8 +168,7 @@ nginx_conf:
 # letsencrypt for Ubuntu yet, but once there is, we should switch to that.
 really_reset_letsencrypt:
   cmd.run:
-    - name: git reset --hard HEAD
-    - cwd: {{ letsencrypt_dir }}
+    - name: cd {{ letsencrypt_dir}} && git reset --hard HEAD
     - onlyif: test -e {{ letsencrypt_dir }}/.git
 
 install_letsencrypt:

--- a/project/web/balancer.sls
+++ b/project/web/balancer.sls
@@ -205,12 +205,8 @@ link_key:
     - force: true
     - require:
       - file: link_cert
-
-reload_nginx_for_cert:
-  cmd.run:
-    - name: service nginx reload
-    - require:
-      - file: link_key
+    - watch_in:
+      - service: nginx
 
 # Once a week, renew our cert(s) if we need to. This will only renew them if
 # they're within 30 days of expiring, so it's not a big burden on the certificate

--- a/project/web/balancer.sls
+++ b/project/web/balancer.sls
@@ -166,12 +166,18 @@ nginx_conf:
 # To install letsencrypt for now, just clone the latest version and invoke the
 # ``letsencrypt-auto`` script from there. There's not a packaged version of
 # letsencrypt for Ubuntu yet, but once there is, we should switch to that.
+really_reset_letsencrypt:
+  cmd.run:
+    - name: git reset --hard HEAD
+    - cwd: {{ letsencrypt_dir }}
+    - onlyif: test -e {{ letsencrypt_dir }}/.git
+
 install_letsencrypt:
   git.latest:
     - name: https://github.com/letsencrypt/letsencrypt/
     - target: {{ letsencrypt_dir }}
-    - force_checkout: True
-    - force_reset: True
+    - require:
+        - cmd: really_reset_letsencrypt
 
 # Run letsencrypt to get a key and certificate
 run_letsencrypt:


### PR DESCRIPTION
I haven't had a chance to test this yet.

I'm hoping that on a first run, the `onlyif` test would return false, so the `git reset` would NOT get run, and only `install_letsencrypt` would get run. Every subsequent run, the `onlyif` test would return true, so the `git reset` would run before the `install_letsencrypt`

This is another attempt at fixing #133 since it seems the salt version didn't work. (per testing on edxpass)
