### PR TITLE
Always migrate during deploy.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,14 @@ Margarita
 
 Changes - always add to the top.
 
+v 1.7.4 on August 17, 2016
+--------------------------
+
+* Always run migrate during deploy. Previously "migrate --list" was used in an attempt to
+only run migrate when needed, but "migrate --list" no longer exists with Django 1.10. The new
+variant, showmigrations, didn't exist in Django 1.7. For now, to allow supporting a wide range
+of Django versions on deploy, it's easiest to simply run migrate on every deploy.
+
 v 1.7.3 on July 1, 2016
 -----------------------
 

--- a/project/web/app.sls
+++ b/project/web/app.sls
@@ -86,7 +86,6 @@ migrate:
     - name: "{{ vars.path_from_root('manage.sh') }} migrate --noinput"
     - user: {{ pillar['project_name'] }}
     - group: {{ pillar['project_name'] }}
-    - onlyif: "{{ vars.path_from_root('manage.sh') }} migrate --list | grep '\\[ \\]'"
     - require:
       - file: manage
     - order: last


### PR DESCRIPTION
migrate --list does not exist in Django 1.10, showmigrations does
not exist in Django 1.7 so supporting a wide range of Django levels
plus only running migrate when absolutely necessary is considerably
harder than simply running migrate during deploy.
