### PR TITLE
Use certbot-auto

### DIFF
--- a/project/web/balancer.sls
+++ b/project/web/balancer.sls
@@ -174,7 +174,7 @@ install_certbot:
 # Run certbot to get a key and certificate
 run_certbot:
   cmd.run:
-    - name: certbot -q certonly --webroot -w {{ vars.public_dir }} {% for domain in letsencrypt_domains %}-d {{ domain }} {% endfor %} --email={{ pillar['admin_email'] }} --agree-tos --text --non-interactive
+    - name: certbot-auto certonly --webroot --webroot-path {{ vars.public_dir }} {% for domain in letsencrypt_domains %}--domain {{ domain }} {% endfor %} --email={{ pillar['admin_email'] }} --agree-tos --text --quiet
     - unless: test -s /etc/letsencrypt/live/{{ pillar['domain'] }}/fullchain.pem -a -s /etc/letsencrypt/live/{{ pillar['domain'] }}/privkey.pem
     - require:
       - file: install_certbot
@@ -204,7 +204,7 @@ link_key:
 # LetsEncrypt initiated revocation) https://certbot.eff.org/#ubuntutrusty-nginx
 renew_certbot:
   cron.present:
-    - name: certbot -q renew && /etc/init.d/nginx reload
+    - name: certbot-auto renew --quiet --no-self-upgrade && /etc/init.d/nginx reload
     - identifier: renew_certbot
     - minute: random
     - hour: "3,15"

--- a/project/web/balancer.sls
+++ b/project/web/balancer.sls
@@ -168,13 +168,12 @@ install_certbot:
   file.managed:
     - name: /usr/local/bin/certbot-auto
     - source: https://dl.eff.org/certbot-auto
-    - source_hash: sha256=fcff7a6a899d1ab576369e5849087b3db7e6cf251e1ea2c963e11b05dfe62e5c
     - mode: 755
 
 # Run certbot to get a key and certificate
 run_certbot:
   cmd.run:
-    - name: certbot-auto certonly --webroot --webroot-path {{ vars.public_dir }} {% for domain in letsencrypt_domains %}--domain {{ domain }} {% endfor %} --email={{ pillar['admin_email'] }} --agree-tos --text --quiet
+    - name: certbot-auto certonly --webroot --webroot-path {{ vars.public_dir }} {% for domain in letsencrypt_domains %}--domain {{ domain }} {% endfor %} --email={{ pillar['admin_email'] }} --agree-tos --text --quiet --no-self-upgrade
     - unless: test -s /etc/letsencrypt/live/{{ pillar['domain'] }}/fullchain.pem -a -s /etc/letsencrypt/live/{{ pillar['domain'] }}/privkey.pem
     - require:
       - file: install_certbot
@@ -204,7 +203,7 @@ link_key:
 # LetsEncrypt initiated revocation) https://certbot.eff.org/#ubuntutrusty-nginx
 renew_certbot:
   cron.present:
-    - name: certbot-auto renew --quiet --no-self-upgrade && /etc/init.d/nginx reload
+    - name: certbot-auto renew --quiet --no-self-upgrade --post-hook "service nginx reload"
     - identifier: renew_certbot
     - minute: random
     - hour: "3,15"

--- a/project/web/balancer.sls
+++ b/project/web/balancer.sls
@@ -191,6 +191,8 @@ verify_certbot_download:
   cmd.run:
     - name: gpg2 --trusted-key 4D17C995CD9775F2 --verify /tmp/certbot-auto.asc /usr/local/bin/certbot-auto
     - require:
+      - file: /tmp/certbot-auto.asc
+      - file: install_certbot
       - cmd: receive_certbot_gpg_key
 
 # Run certbot to get a key and certificate
@@ -200,7 +202,7 @@ run_certbot:
     - unless: test -s /etc/letsencrypt/live/{{ pillar['domain'] }}/fullchain.pem -a -s /etc/letsencrypt/live/{{ pillar['domain'] }}/privkey.pem
     - require:
       - file: install_certbot
-      - gpg: verify_certbot_download
+      - cmd: verify_certbot_download
       - file: nginx_conf
 
 link_cert:

--- a/project/web/balancer.sls
+++ b/project/web/balancer.sls
@@ -168,6 +168,7 @@ install_certbot:
   file.managed:
     - name: /usr/local/bin/certbot-auto
     - source: https://dl.eff.org/certbot-auto
+    - skip_verify: True
     - mode: 755
 
 # Run certbot to get a key and certificate


### PR DESCRIPTION
This PR is an edited version of @jbradberry's #149 which uses `certbot-auto` instead of a git checkout or pip installation. I've tested it by creating an instance using the old version, and then successfully upgrading it to this version.