### PR TITLE
Letsencrypt improvements for multiple domains

### DIFF
--- a/project/web/balancer.sls
+++ b/project/web/balancer.sls
@@ -198,7 +198,7 @@ verify_certbot_download:
 # Run certbot to get a key and certificate
 run_certbot:
   cmd.run:
-    - name: certbot-auto certonly --webroot --webroot-path {{ vars.public_dir }} {% for domain in letsencrypt_domains %}--domain {{ domain }} {% endfor %} --email={{ pillar['admin_email'] }} --agree-tos --text --quiet --no-self-upgrade
+    - name: certbot-auto certonly --webroot --webroot-path {{ vars.public_dir }} {% for domain in letsencrypt_domains %}--domain {{ domain }} {% endfor %} --email={{ pillar['admin_email'] }} --agree-tos --text --quiet --no-self-upgrade --expand
     - unless: test -s /etc/letsencrypt/live/{{ pillar['domain'] }}/fullchain.pem -a -s /etc/letsencrypt/live/{{ pillar['domain'] }}/privkey.pem
     - require:
       - file: install_certbot

--- a/project/web/balancer.sls
+++ b/project/web/balancer.sls
@@ -47,7 +47,7 @@ ssl_dir:
 # so that we can run nginx while getting the real certificate from letsencrypt.
 ssl_cert:
   cmd.run:
-    - name: cd {{ vars.ssl_dir }} && /var/lib/nginx/generate-cert.sh {{ pillar['domain'] }}
+    - name: cd {{ vars.ssl_dir }} && ([ -e {{ pillar['domain'] }}.crt ] || /var/lib/nginx/generate-cert.sh {{ pillar['domain'] }})
     - cwd: {{ vars.ssl_dir }}
     - user: root
     - unless: test -s {{ ssl_certificate }}
@@ -198,7 +198,7 @@ verify_certbot_download:
 # Run certbot to get a key and certificate
 run_certbot:
   cmd.run:
-    - name: certbot-auto certonly --webroot --webroot-path {{ vars.public_dir }} {% for domain in letsencrypt_domains %}--domain {{ domain }} {% endfor %} --email={{ pillar['admin_email'] }} --agree-tos --text --quiet --no-self-upgrade --expand
+    - name: certbot-auto certonly --webroot --webroot-path {{ vars.public_dir }} --cert-name {{ pillar['domain'] }} {% for domain in letsencrypt_domains %}--domain {{ domain }} {% endfor %} --email={{ pillar['admin_email'] }} --agree-tos --text --quiet --no-self-upgrade --expand
     - unless: test -s /etc/letsencrypt/live/{{ pillar['domain'] }}/fullchain.pem -a -s /etc/letsencrypt/live/{{ pillar['domain'] }}/privkey.pem
     - require:
       - file: install_certbot

--- a/project/web/balancer.sls
+++ b/project/web/balancer.sls
@@ -37,7 +37,7 @@ ssl_dir:
     - name: {{ vars.ssl_dir }}
     - user: root
     - group: www-data
-    - mode: 644
+    - mode: 755
     - makedirs: True
     - require:
       - file: root_dir


### PR DESCRIPTION
* Use `--cert-name` with the primary domain, so that letsencrypt will name the certificate the same as what the rest of our config is expecting.
* Use `--expand`, because otherwise, if we change the list of domains, certbot will stop and prompt as to whether it should add the domains to the certificate.
* Also add the `x` permission to the ssl dir, which didn't seem to break anything but likely only because all this runs as root.