### PR TITLE
X-Forwarded-Proto

### DIFF
--- a/project/web/site.conf
+++ b/project/web/site.conf
@@ -83,7 +83,15 @@ server {
         {% endif %}
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        # The proper header is "X-Forwarded-Proto", not "X-Forwarded-Protocol".
+        # But we've been setting X-Forwarded-Protocol for years, so we might
+        # have projects that are using it. New projects should NOT use it.
+        # Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto
         proxy_set_header X-Forwarded-Protocol ssl;
+        # Here's the proper header:
+        proxy_set_header X-Forwarded-Proto ssl;
+
         proxy_set_header Host {{ pillar['domain'] }};
         proxy_redirect off;
         proxy_buffering on;


### PR DESCRIPTION
We've been setting X-Forwarded-Protocol, but the proper
header is X-Forwarded-Proto.  Add the proper one, but
keep the one we've been setting to avoid breaking
any existing projects that might expect it. Add a note
of explanation.