### PR TITLE
Cron can't find certbot-auto

### DIFF
--- a/project/web/balancer.sls
+++ b/project/web/balancer.sls
@@ -229,7 +229,7 @@ link_key:
 # LetsEncrypt initiated revocation) https://certbot.eff.org/#ubuntutrusty-nginx
 renew_certbot:
   cron.present:
-    - name: certbot-auto renew --quiet --no-self-upgrade --post-hook "service nginx reload"
+    - name: /usr/local/bin/certbot-auto renew --quiet --no-self-upgrade --post-hook "/usr/sbin/service nginx reload"
     - identifier: renew_certbot
     - minute: random
     - hour: "3,15"


### PR DESCRIPTION
Checked to see if CW staging renewed its LetsEncrypt cert and found that it hadn't. After poking around, I found that these errors are getting mailed to the root user:

```
From root@ip-172-30-1-149.ec2.internal  Wed Feb 15 03:39:01 2017
Return-Path: <root@ip-172-30-1-149.ec2.internal>
X-Original-To: root
Delivered-To: root@ip-172-30-1-149.ec2.internal
Received: by ip-172-30-1-149.ec2.internal (Postfix, from userid 0)
        id 83B7B808AC; Wed, 15 Feb 2017 03:39:01 +0000 (UTC)
From: root@ip-172-30-1-149.ec2.internal (Cron Daemon)
To: root@ip-172-30-1-149.ec2.internal
Subject: Cron <root@ip-172-30-1-149> certbot-auto renew --quiet --no-self-upgrade --post-hook "service nginx reload"
MIME-Version: 1.0
Content-Type: text/plain; charset=UTF-8
Content-Transfer-Encoding: 8bit
X-Cron-Env: <SHELL=/bin/sh>
X-Cron-Env: <HOME=/root>
X-Cron-Env: <PATH=/usr/bin:/bin>
X-Cron-Env: <LOGNAME=root>
Message-Id: <20170215033901.83B7B808AC@ip-172-30-1-149.ec2.internal>
Date: Wed, 15 Feb 2017 03:39:01 +0000 (UTC)

/bin/sh: 1: certbot-auto: not found

```

There's no easy way to set the `PATH` in the crontab via salt, so I figured it was just easier to use the full command path.

cc: @jbradberry This may also be happening in tequila?