### PR TITLE
Add /usr/local/bin to path for certbot cron job

### DIFF
--- a/project/web/balancer.sls
+++ b/project/web/balancer.sls
@@ -229,7 +229,7 @@ link_key:
 # LetsEncrypt initiated revocation) https://certbot.eff.org/#ubuntutrusty-nginx
 renew_certbot:
   cron.present:
-    - name: /usr/local/bin/certbot-auto renew --quiet --no-self-upgrade --post-hook "/usr/sbin/service nginx reload"
+    - name: /usr/bin/env PATH=/usr/local/bin:$PATH /usr/local/bin/certbot-auto renew --quiet --no-self-upgrade --post-hook "/usr/sbin/service nginx reload"
     - identifier: renew_certbot
     - minute: random
     - hour: "3,15"


### PR DESCRIPTION
Certificate renewals seemed to be failing on a site due to this. Error output from the failed renewal indicated difficulty finding virtualenv, which was at /usr/local/bin/. The path was just /usr/bin:/bin.
