### PR TITLE
Put Celerybeat PID file on temp filesystem

### DIFF
--- a/project/worker/beat.sls
+++ b/project/worker/beat.sls
@@ -21,7 +21,7 @@ beat_conf:
         name: "celery-beat"
         use_newrelic: {{ vars.use_newrelic }}
         command: "beat"
-        flags: "--schedule={{ vars.path_from_root('celerybeat-schedule.db') }} --pidfile={{ vars.path_from_root('celerybeat.pid') }} --loglevel=INFO"
+        flags: "--schedule={{ vars.path_from_root('celerybeat-schedule.db') }} --pidfile=/var/run/celerybeat.pid --loglevel=INFO"
     - require:
       - pip: supervisor
       - file: log_dir


### PR DESCRIPTION
@kmtracey noticed that during an unscheduled reboot, celerybeat didn't restart because the PID file was still in place. @dpoirier mentioned that we should place these files on a temporary filesystem so that, on reboot, they would no longer be present.

This [link](https://superuser.com/a/454454) recommends that they be placed in /var/run (which soft links to /run in Ubuntu, a temporary filesystem) 